### PR TITLE
Fix build failure (undefined reference to __atomic_load_16)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(COMPILE_OPTIONS
     -Wno-unused-variable
     -Wno-unknown-pragmas
     -fPIC
-	-march=native
+    -march=native
 )
 
 ## TARGET lmdb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(COMPILE_OPTIONS
     -Wno-unused-variable
     -Wno-unknown-pragmas
     -fPIC
-		-march=native
+	-march=native
 )
 
 ## TARGET lmdb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(COMPILE_OPTIONS
     -Wno-unused-variable
     -Wno-unknown-pragmas
     -fPIC
+		-march=native
 )
 
 ## TARGET lmdb


### PR DESCRIPTION
While I was trying to compile nogdb test on Debian 9.4 Stretch with g++ 6.3, I kept receiving errors

> undefined reference to `__atomic_load_16'

https://stackoverflow.com/questions/37613415/c-undefined-reference-to-atomic-load-16 
suggests that some machine doesn't support native atomic operations so you should add `-march=native` into compile options.